### PR TITLE
manifest: updated source name corrected

### DIFF
--- a/snippets/pixelage.xml
+++ b/snippets/pixelage.xml
@@ -97,7 +97,7 @@
   <!-- vendor -->
   <project path="vendor/certification" name="android_vendor_certification" remote="pixelage" />
   <project path="vendor/custom-preference" name="android_vendor_custom-preference" remote="pixelage" />
-  <project path="vendor/gms" name="android_vendor_gms" remote="pixelage-gitea" clone-depth="1" />
+  <project path="vendor/gms" name="vendor_gms" remote="pixelage-gitea" clone-depth="1" />
   <project path="vendor/pixelage" name="android_vendor_pixelage" remote="pixelage" />
 
   <!-- CodeLinaro additions -->


### PR DESCRIPTION
The vendor_gms resource name published on gitea.com has been corrected.